### PR TITLE
switch to the more-maintained builtin::compat

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,6 +1,6 @@
 requires "perl" => "v5.34";
 
-requires "builtin::Backport" => "0";
+requires "builtin::compat" => "0.003003";
 requires "stable" => "0.031";
 requires "Compress::Raw::Zlib" => "2.070";
 requires "IO::Compress::Zip" => "0";

--- a/lib/Archive/SCS/Directory.pm
+++ b/lib/Archive/SCS/Directory.pm
@@ -5,9 +5,8 @@ use Object::Pad 0.73 ':experimental(adjust_params)';
 class Archive::SCS::Directory 1.08
   :isa( Archive::SCS::Mountable );
 
-use builtin 'reftype';
+use builtin::compat 'reftype';
 use stable 0.031 'isa';
-no warnings 'experimental::builtin';
 
 use Archive::SCS::CityHash 'cityhash64';
 use Archive::SCS::DirIndex;

--- a/lib/Archive/SCS/GameDir.pm
+++ b/lib/Archive/SCS/GameDir.pm
@@ -4,8 +4,7 @@ use Object::Pad 0.73;
 
 class Archive::SCS::GameDir 1.08;
 
-use builtin 'trim';
-no warnings 'experimental::builtin';
+use builtin::compat 'trim';
 
 use Archive::SCS;
 use Carp 'croak';

--- a/lib/Archive/SCS/Zip.pm
+++ b/lib/Archive/SCS/Zip.pm
@@ -5,9 +5,8 @@ use Object::Pad 0.73;
 class Archive::SCS::Zip 1.08
   :isa( Archive::SCS::Mountable );
 
-use builtin qw( blessed true );
+use builtin::compat qw( blessed true );
 use stable 0.031 'isa';
-no warnings 'experimental::builtin';
 
 use Archive::SCS::CityHash 'cityhash64';
 use Archive::SCS::DirIndex;


### PR DESCRIPTION
see https://rt.cpan.org/Ticket/Display.html?id=158702.

(unfortunately I can't test this patch as ExtUtils::CppGuess doesn't compile on darwin)